### PR TITLE
fix: catch uncaught exceptions from pull in dialer.handle

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
     "lodash.range": "^3.2.0",
     "once": "^1.4.0",
     "pull-handshake": "^1.1.4",
-    "pull-length-prefixed": "^1.3.0",
+    "pull-length-prefixed": "^1.3.1",
     "pull-stream": "^3.6.7",
     "semver": "^5.5.0",
     "varint": "^5.0.0"
   },
   "devDependencies": {
-    "aegir": "^13.1.0",
+    "aegir": "^15.1.0",
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
     "libp2p-multiplex": "~0.5.1",

--- a/src/dialer/index.js
+++ b/src/dialer/index.js
@@ -44,11 +44,17 @@ class Dialer {
       callback()
     }, this.log)
 
-    pull(
-      rawConn,
-      s,
-      rawConn
-    )
+    // Handle unexpected errors from pull, like 'already piped'
+    try {
+      pull(
+        rawConn,
+        s,
+        rawConn
+      )
+    } catch (err) {
+      this.log.error(err)
+      callback(err)
+    }
   }
 
   /**


### PR DESCRIPTION
This should prevent https://github.com/ipfs/js-ipfs/issues/1446 from crashing ipfs nodes. Uncaught errors like `Already piped` will be caught and logged as errors.