### PR TITLE
fix: dont mutate select protocols

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -6,7 +6,7 @@ const multistream = require('./multistream')
 const handshake = require('it-handshake')
 
 module.exports = async (stream, protocols, protocolId) => {
-  protocols = Array.isArray(protocols) ? protocols : [protocols]
+  protocols = Array.isArray(protocols) ? [...protocols] : [protocols]
   const { reader, writer, rest, stream: shakeStream } = handshake(stream)
 
   const protocol = protocols.shift()

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -83,6 +83,7 @@ describe('Dialer', () => {
 
       const mss = new MSS.Dialer(duplex)
       const selection = await mss.select(protocols)
+      expect(protocols).to.have.length(2)
       expect(selection.protocol).to.equal(selectedProtocol)
 
       // Ensure stream is usable after selection


### PR DESCRIPTION
When passed as an array, `.select` was mutating the protocol list by calling shift. This fixes that by internally using a clone of the array.