### PR TITLE
Remove unused it-pushable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "it-handshake": "^1.0.0",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
-    "it-pushable": "^1.3.1",
     "it-reader": "^2.0.0",
     "p-defer": "^3.0.0"
   },


### PR DESCRIPTION
Pretty sure this is unused. There's some entries in the source map files published to npm but I assume that's not load bearing?