### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const { stream: dhtStream, protocol } = await mss.select([
 // ...it might then do something like this:
 // try {
 //   await pipe(
-//     [Buffer.from('Some DHT data')]
+//     [uint8ArrayFromString('Some DHT data')]
 //     dhtStream,
 //     async source => {
 //       for await (const chunk of source)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "bl": "^4.0.0",
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
-    "it-handshake": "achingbrain/it-handshake#fix/unhandled-promise-rejection",
+    "it-handshake": "^1.0.2",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
     "it-reader": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,23 +41,23 @@
   "homepage": "https://github.com/multiformats/js-multistream-select#readme",
   "dependencies": {
     "bl": "^4.0.0",
-    "buffer": "^5.2.1",
     "debug": "^4.1.1",
     "err-code": "^2.0.0",
-    "it-handshake": "^1.0.0",
+    "it-handshake": "achingbrain/it-handshake#fix/unhandled-promise-rejection",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
     "it-reader": "^2.0.0",
-    "p-defer": "^3.0.0"
+    "p-defer": "^3.0.0",
+    "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^20.0.0",
+    "aegir": "^25.1.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
-    "mocha": "^6.2.0",
+    "mocha": "^8.1.1",
     "p-timeout": "^3.2.0",
-    "streaming-iterables": "^4.1.0",
+    "streaming-iterables": "^5.0.2",
     "varint": "^5.0.0"
   },
   "contributors": [

--- a/src/multistream.js
+++ b/src/multistream.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const BufferList = require('bl/BufferList')
 const lp = require('it-length-prefixed')
 const pipe = require('it-pipe')
 const errCode = require('err-code')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
-const NewLine = Buffer.from('\n')
+const NewLine = uint8ArrayFromString('\n')
 
 async function oneChunk (source) {
   for await (const chunk of source) return chunk // We only need one!

--- a/test/dialer.spec.js
+++ b/test/dialer.spec.js
@@ -2,12 +2,9 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 5] */
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const { expect } = chai
+const { expect } = require('aegir/utils/chai')
 const pipe = require('it-pipe')
 const { collect } = require('streaming-iterables')
-const Crypto = require('crypto')
 const BufferList = require('bl/BufferList')
 const Pair = require('it-pair')
 const Reader = require('it-reader')
@@ -15,6 +12,7 @@ const pTimeout = require('p-timeout')
 const throwsAsync = require('./helpers/throws-async')
 const Multistream = require('../src/multistream')
 const MSS = require('../')
+const randomBytes = require('./helpers/random-bytes')
 
 describe('Dialer', () => {
   describe('dialer.select', () => {
@@ -27,7 +25,7 @@ describe('Dialer', () => {
       expect(selection.protocol).to.equal(protocol)
 
       // Ensure stream is usable after selection
-      const input = [Crypto.randomBytes(10), Crypto.randomBytes(64), Crypto.randomBytes(3)]
+      const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
       const output = await pipe(input, selection.stream, collect)
       expect(BufferList(output).slice()).to.eql(BufferList(input).slice())
     })
@@ -87,7 +85,7 @@ describe('Dialer', () => {
       expect(selection.protocol).to.equal(selectedProtocol)
 
       // Ensure stream is usable after selection
-      const input = [Crypto.randomBytes(10), Crypto.randomBytes(64), Crypto.randomBytes(3)]
+      const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
       const output = await pipe(input, selection.stream, collect)
       expect(BufferList(output).slice()).to.eql(BufferList(input).slice())
     })
@@ -169,7 +167,7 @@ describe('Dialer', () => {
       expect(selection.protocol).to.equal(selectedProtocol)
 
       // Ensure stream is usable after selection
-      const input = [Crypto.randomBytes(10), Crypto.randomBytes(64), Crypto.randomBytes(3)]
+      const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
       const output = await pipe(input, selection.stream, collect)
       expect(BufferList(output).slice()).to.eql(BufferList(input).slice())
     })

--- a/test/helpers/random-bytes.js
+++ b/test/helpers/random-bytes.js
@@ -1,0 +1,11 @@
+'use strict'
+
+function getRandomInt (max) {
+  return Math.floor(Math.random() * Math.floor(max))
+}
+
+function randomBytes (num) {
+  return new Uint8Array(num).map(() => getRandomInt(256))
+}
+
+module.exports = randomBytes

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -6,9 +6,9 @@ chai.use(require('dirty-chai'))
 const { expect } = chai
 const pipe = require('it-pipe')
 const { collect } = require('streaming-iterables')
-const Crypto = require('crypto')
 const BufferList = require('bl/BufferList')
 const DuplexPair = require('it-pair/duplex')
+const randomBytes = require('./helpers/random-bytes')
 const MSS = require('../')
 
 describe('Dialer and Listener integration', () => {
@@ -29,7 +29,7 @@ describe('Dialer and Listener integration', () => {
     expect(listenerSelection.protocol).to.equal(selectedProtocol)
 
     // Ensure stream is usable after selection
-    const input = [Crypto.randomBytes(10), Crypto.randomBytes(64), Crypto.randomBytes(3)]
+    const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
     const output = await Promise.all([
       pipe(input, dialerSelection.stream, collect),
       pipe(listenerSelection.stream, listenerSelection.stream)
@@ -58,7 +58,7 @@ describe('Dialer and Listener integration', () => {
     expect(listenerSelection.protocol).to.equal(selectedProtocol)
 
     // Ensure stream is usable after selection
-    const input = [Crypto.randomBytes(10), Crypto.randomBytes(64), Crypto.randomBytes(3)]
+    const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
     const output = await Promise.all([
       pipe(input, dialerSelection.stream, collect),
       pipe(listenerSelection.stream, listenerSelection.stream)

--- a/test/listener.spec.js
+++ b/test/listener.spec.js
@@ -5,19 +5,19 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const { expect } = chai
 const pipe = require('it-pipe')
-const Crypto = require('crypto')
 const BufferList = require('bl/BufferList')
 const Reader = require('it-reader')
 const { collect } = require('streaming-iterables')
 const Lp = require('it-length-prefixed')
 const Multistream = require('../src/multistream')
+const randomBytes = require('./helpers/random-bytes')
 const MSS = require('../')
 
 describe('Listener', () => {
   describe('listener.handle', () => {
     it('should handle a protocol', async () => {
       const protocol = '/echo/1.0.0'
-      const input = [Crypto.randomBytes(10), Crypto.randomBytes(64), Crypto.randomBytes(3)]
+      const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
 
       const duplex = {
         sink: async source => {
@@ -54,7 +54,7 @@ describe('Listener', () => {
       const protocols = ['/echo/2.0.0', '/echo/1.0.0']
       const handledProtocols = ['/test/1.0.0', protocols[protocols.length - 1]]
       const handledProtocol = protocols[protocols.length - 1]
-      const input = [Crypto.randomBytes(10), Crypto.randomBytes(64), Crypto.randomBytes(3)]
+      const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
 
       const duplex = {
         sink: async source => {
@@ -97,7 +97,7 @@ describe('Listener', () => {
       const protocols = ['/echo/2.0.0', '/echo/1.0.0']
       const handledProtocols = ['/test/1.0.0', protocols[protocols.length - 1]]
       const handledProtocol = protocols[protocols.length - 1]
-      const input = [Crypto.randomBytes(10), Crypto.randomBytes(64), Crypto.randomBytes(3)]
+      const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
 
       const duplex = {
         sink: async source => {

--- a/test/multistream.spec.js
+++ b/test/multistream.spec.js
@@ -9,30 +9,32 @@ const BufferList = require('bl/BufferList')
 const Reader = require('it-reader')
 const throwsAsync = require('./helpers/throws-async')
 const Multistream = require('../src/multistream')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayConcat = require('uint8arrays/concat')
 
 describe('Multistream', () => {
   describe('Multistream.encode', () => {
     it('should encode data Buffer as a multistream-select message', () => {
-      const input = Buffer.from(`TEST${Date.now()}`)
+      const input = uint8ArrayFromString(`TEST${Date.now()}`)
       const output = Multistream.encode(input)
 
-      const expected = Buffer.concat([
-        Buffer.from(Varint.encode(input.length + 1)), // +1 to include newline
+      const expected = uint8ArrayConcat([
+        Uint8Array.from(Varint.encode(input.length + 1)), // +1 to include newline
         input,
-        Buffer.from('\n')
+        uint8ArrayFromString('\n')
       ])
 
       expect(output.slice()).to.eql(expected)
     })
 
     it('should encode data BufferList as a multistream-select message', () => {
-      const input = new BufferList([Buffer.from('TEST'), Buffer.from(`${Date.now()}`)])
+      const input = new BufferList([uint8ArrayFromString('TEST'), uint8ArrayFromString(`${Date.now()}`)])
       const output = Multistream.encode(input)
 
-      const expected = Buffer.concat([
-        Buffer.from(Varint.encode(input.length + 1)), // +1 to include newline
+      const expected = uint8ArrayConcat([
+        Uint8Array.from(Varint.encode(input.length + 1)), // +1 to include newline
         input.slice(),
-        Buffer.from('\n')
+        uint8ArrayFromString('\n')
       ])
 
       expect(output.slice()).to.eql(expected)
@@ -41,16 +43,16 @@ describe('Multistream', () => {
 
   describe('Multistream.write', () => {
     it('should encode and write a multistream-select message', () => {
-      const input = Buffer.from(`TEST${Date.now()}`)
+      const input = uint8ArrayFromString(`TEST${Date.now()}`)
       const output = []
       const mockWriter = { push: d => output.push(d) }
 
       Multistream.write(mockWriter, input)
 
-      const expected = Buffer.concat([
-        Buffer.from(Varint.encode(input.length + 1)), // +1 to include newline
+      const expected = uint8ArrayConcat([
+        Uint8Array.from(Varint.encode(input.length + 1)), // +1 to include newline
         input,
-        Buffer.from('\n')
+        uint8ArrayFromString('\n')
       ])
 
       expect(output.length).to.equal(1)
@@ -60,12 +62,12 @@ describe('Multistream', () => {
 
   describe('Multistream.read', () => {
     it('should decode a multistream-select message', async () => {
-      const input = Buffer.from(`TEST${Date.now()}`)
+      const input = uint8ArrayFromString(`TEST${Date.now()}`)
 
-      const reader = Reader([Buffer.concat([
-        Buffer.from(Varint.encode(input.length + 1)), // +1 to include newline
+      const reader = Reader([uint8ArrayConcat([
+        Uint8Array.from(Varint.encode(input.length + 1)), // +1 to include newline
         input,
-        Buffer.from('\n')
+        uint8ArrayFromString('\n')
       ])])
 
       const output = await Multistream.read(reader)
@@ -73,10 +75,10 @@ describe('Multistream', () => {
     })
 
     it('should throw for non-newline delimited message', async () => {
-      const input = Buffer.from(`TEST${Date.now()}`)
+      const input = uint8ArrayFromString(`TEST${Date.now()}`)
 
-      const reader = Reader([Buffer.concat([
-        Buffer.from(Varint.encode(input.length)),
+      const reader = Reader([uint8ArrayConcat([
+        Uint8Array.from(Varint.encode(input.length)),
         input
       ])])
 


### PR DESCRIPTION
Updates all deps.

Depends on:

- [x] https://github.com/jacobheun/it-handshake/pull/2

BREAKING CHANGES

- All use of node Buffers has been replaced with Uint8Arrays