### PR TITLE
fix: types again

### DIFF
--- a/src/handle.js
+++ b/src/handle.js
@@ -12,7 +12,7 @@ const log = Object.assign(debug('mss:handle'), {
 })
 
 /**
- * @typedef {import('./types').DuplexStream<Uint8Array>} DuplexStream
+ * @typedef {import('./types').DuplexStream<Uint8Array | BufferList>} DuplexStream
  * @typedef {import('./types').AbortOptions} AbortOptions
  */
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ const { PROTOCOL_ID } = require('./constants')
 exports.PROTOCOL_ID = PROTOCOL_ID
 
 /**
- * @typedef {import('./types').DuplexStream<Uint8Array>} DuplexStream
+ * @typedef {import('bl/BufferList')} BufferList
+ * @typedef {import('./types').DuplexStream<Uint8Array | BufferList>} DuplexStream
  * @typedef {import('./types').AbortOptions} AbortOptions
  */
 
@@ -24,8 +25,7 @@ class MultistreamSelect {
   /**
    * Perform the multistream-select handshake
    *
-   * @param {object} [options]
-   * @param {AbortSignal} options.signal
+   * @param {AbortOptions} [options]
    */
   async _handshake (options) {
     if (this._shaken) return
@@ -38,16 +38,14 @@ class MultistreamSelect {
 class Dialer extends MultistreamSelect {
   /**
    * @param {string | string[]} protocols
-   * @param {object} [options]
-   * @param {AbortSignal} options.signal
+   * @param {AbortOptions} [options]
    */
   select (protocols, options) {
     return select(this._stream, protocols, this._shaken ? undefined : PROTOCOL_ID, options)
   }
 
   /**
-   * @param {object} [options]
-   * @param {AbortSignal} options.signal
+   * @param {AbortOptions} [options]
    */
   async ls (options) {
     await this._handshake(options)

--- a/src/ls.js
+++ b/src/ls.js
@@ -14,8 +14,8 @@ const log = Object.assign(debug('mss:ls'), {
 })
 
 /**
- * @typedef {import('./types').DuplexStream<Uint8Array>} DuplexStream
  * @typedef {import('bl/BufferList')} BufferList
+ * @typedef {import('./types').DuplexStream<Uint8Array | BufferList>} DuplexStream
  * @typedef {import('./types').AbortOptions} AbortOptions
  */
 

--- a/src/select.js
+++ b/src/select.js
@@ -11,8 +11,8 @@ const log = Object.assign(debug('mss:select'), {
 })
 
 /**
- * @typedef {import('./types').DuplexStream<Uint8Array>} DuplexStream
  * @typedef {import('bl/BufferList')} BufferList
+ * @typedef {import('./types').DuplexStream<Uint8Array | BufferList>} DuplexStream
  * @typedef {import('./types').AbortOptions} AbortOptions
  */
 


### PR DESCRIPTION
Make duplex streams accept buffer lists as well as uint8arrays and fix final few uses of AbortOptions.